### PR TITLE
Docs: enhanced compose and deployment troubleshooting guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+work
+
+# Git worktrees (project-local)
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Cloudflare Access Service Token support for Agent transport. When the DockFlare Master is protected by Cloudflare Access policies, set `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` to authenticate without IP bypass. Enables deployment on any host regardless of network origin.
+- New `transport.py` module centralizing auth headers (Bearer API key and optional CF-Access headers).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ All notable changes to this project will be documented in this file.
 
 - Cloudflare Access Service Token support for Agent transport. When the DockFlare Master is protected by Cloudflare Access policies, set `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` to authenticate without IP bypass. Enables deployment on any host regardless of network origin.
 - New `transport.py` module centralizing auth headers (Bearer API key and optional CF-Access headers).
+- HTTP health check endpoint (`GET /health` on `HEALTH_CHECK_PORT`, default 8080) with status, tunnel state, master connection, and thread health. Merged from `origin/dev`.

--- a/DockFlare-Agent/cloudflare_api.py
+++ b/DockFlare-Agent/cloudflare_api.py
@@ -1,17 +1,19 @@
 import requests
 import logging
 
-def update_tunnel_config(master_url, api_key, tunnel_id, ingress_rules):
+def update_tunnel_config(master_url, headers, tunnel_id, ingress_rules):
     """
     Updates the Cloudflare tunnel configuration for the agent.
     """
-    if not all([master_url, api_key, tunnel_id]):
-        logging.error("Missing master_url, api_key, or tunnel_id for tunnel config update.")
+    if not all([master_url, headers, tunnel_id]):
+        logging.error("Missing master_url, headers, or tunnel_id for tunnel config update.")
         return False
 
-    endpoint = f"/accounts/{get_account_id(master_url, api_key)}/cfd_tunnel/{tunnel_id}/configurations"
+    account_id = get_account_id(master_url, headers)
+    if not account_id:
+        return False
+    endpoint = f"/accounts/{account_id}/cfd_tunnel/{tunnel_id}/configurations"
     url = f"{master_url.rstrip('/')}{endpoint}"
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
     payload = {"config": {"ingress": ingress_rules}}
 
     try:
@@ -37,13 +39,12 @@ def generate_ingress_rules(rules):
     ingress.append({"service": "http_status:404"})
     return ingress
 
-def get_account_id(master_url, api_key):
+def get_account_id(master_url, headers):
     """
     Retrieves the Cloudflare account ID from the master.
     """
     endpoint = "/accounts"
     url = f"{master_url.rstrip('/')}{endpoint}"
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
 
     try:
         response = requests.get(url, headers=headers, timeout=15)

--- a/DockFlare-Agent/main.py
+++ b/DockFlare-Agent/main.py
@@ -7,7 +7,9 @@ import requests
 import logging
 import tempfile
 from threading import Thread
+from datetime import datetime, timezone
 from dotenv import load_dotenv
+from flask import Flask, jsonify
 import cloudflare_api
 
 DEFAULT_CLOUDFLARED_IMAGE = "cloudflare/cloudflared:2025.9.0"
@@ -31,8 +33,7 @@ def _normalize_cloudflared_image(raw_value, default_image):
     if not candidate:
         logging.warning("CLOUDFLARED_IMAGE is blank after trimming; falling back to default %s", default_image)
         return default_image
-
-    # Split on whitespace to drop inline comments or accidental extra tokens.
+    
     candidate = candidate.split()[0]
 
     if "#" in candidate:
@@ -53,13 +54,11 @@ def _normalize_cloudflared_image(raw_value, default_image):
 
     return candidate
 
-# Basic Logging Configuration (configurable via LOG_LEVEL env var; default INFO)
 _LOG_LEVEL_STR = os.getenv('LOG_LEVEL', 'INFO').upper()
 _LOG_LEVEL = getattr(logging, _LOG_LEVEL_STR, logging.INFO)
 logging.basicConfig(level=_LOG_LEVEL, format='%(asctime)s - %(levelname)s - %(message)s')
 logging.getLogger().info(f"Logging initialized at level: {_LOG_LEVEL_STR}")
 
-# Load environment variables from .env file
 load_dotenv()
 
 MASTER_URL = os.getenv("DOCKFLARE_MASTER_URL")
@@ -72,7 +71,8 @@ else:
     logging.info(f"Using default cloudflared image: {DEFAULT_CLOUDFLARED_IMAGE}")
 AGENT_ID_FILE = "/app/data/agent_id.txt"
 TUNNEL_STATE_FILE = "/app/data/tunnel_state.json"
-AGENT_ID = None  # Will be assigned by the master
+AGENT_ID = None  
+HEALTH_CHECK_PORT = int(os.getenv("HEALTH_CHECK_PORT", "8080"))
 
 # --- Tunnel Management Globals ---
 tunnel_container = None
@@ -81,6 +81,15 @@ current_tunnel_id = None
 current_tunnel_version = None
 current_tunnel_name = None
 desired_tunnel_state = "unknown"
+
+# --- Health Check Globals ---
+last_successful_master_contact = None
+thread_health_status = {
+    "tunnel_manager": "unknown",
+    "status_reporter": "unknown",
+    "events_listener": "unknown",
+    "health_monitor": "unknown"
+}
 
 
 def fetch_cloudflared_version(container):
@@ -95,7 +104,6 @@ def fetch_cloudflared_version(container):
     except Exception as e:
         logging.error(f"Failed to fetch cloudflared version: {e}")
     return None
-
 
 def load_tunnel_state():
     global current_tunnel_token, current_tunnel_id, current_tunnel_name, desired_tunnel_state
@@ -288,11 +296,11 @@ def report_event_to_master(event_type, container_data=None):
     """
     Sends a JSON payload to the master's reporting endpoint.
     """
+    global last_successful_master_contact
     if not AGENT_ID:
         logging.debug("report_event_to_master called but AGENT_ID is missing; skipping.")
         return
     try:
-        from datetime import datetime, timezone
         payload = {
             "type": event_type,
             "timestamp": datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
@@ -309,6 +317,7 @@ def report_event_to_master(event_type, container_data=None):
         response = requests.post(endpoint, json=payload, headers=headers, timeout=15)
         try:
             response.raise_for_status()
+            last_successful_master_contact = datetime.now(timezone.utc)
             logging.info(f"Successfully reported event to master: {event_type} (status={response.status_code})")
         except requests.exceptions.HTTPError as httpe:
             logging.error(f"HTTP error reporting event to master: {httpe} status={getattr(response, 'status_code', 'unknown')} body={getattr(response, 'text', '')}")
@@ -316,48 +325,129 @@ def report_event_to_master(event_type, container_data=None):
     except requests.exceptions.RequestException as e:
         logging.error(f"Error reporting event to master: {e}")
 
-def listen_for_docker_events(client):
-    """
-    Listens for Docker container events and reports them to the master.
-    """
-    logging.info("Performing initial scan of running containers...")
-    for container in client.containers.list():
-        if is_dockflare_enabled(container.labels):
-            logging.info(f"Found existing container to report: {container.name}")
-            report_event_to_master("container_start", {
-                "id": container.id,
-                "name": container.name,
-                "labels": container.labels
-            })
+# --- Health Check HTTP Server ---
+app = Flask(__name__)
 
-    logging.info("Listening for Docker events...")
-    for event in client.events(decode=True):
+log = logging.getLogger('werkzeug')
+log.setLevel(logging.ERROR)
+
+@app.route('/health', methods=['GET'])
+def health_check():
+    """
+    Health check endpoint that returns agent status.
+    """
+    global last_successful_master_contact, thread_health_status
+
+    seconds_since_contact = None
+    if last_successful_master_contact:
+        seconds_since_contact = int((datetime.now(timezone.utc) - last_successful_master_contact).total_seconds())
+
+    status = "unhealthy"
+    if AGENT_ID:
+        if seconds_since_contact is not None and seconds_since_contact < 120:
+            status = "healthy"
+        elif seconds_since_contact is not None and seconds_since_contact < 300:
+            status = "degraded"
+
+    tunnel_container_running = False
+    if tunnel_container:
         try:
-            if event.get("Type") == "container" and event.get("Action") in ["start", "stop", "die"]:
-                action = event['Action']
-                container_id = event['id']
-                try:
-                    container = client.containers.get(container_id)
-                    labels = container.labels
-                    if is_dockflare_enabled(labels):
+            tunnel_container.reload()
+            tunnel_container_running = tunnel_container.status == 'running'
+        except:
+            pass
+
+    response = {
+        "status": status,
+        "agent_id": AGENT_ID,
+        "registered": AGENT_ID is not None,
+        "tunnel": {
+            "state": desired_tunnel_state,
+            "name": current_tunnel_name,
+            "id": current_tunnel_id,
+            "container_running": tunnel_container_running,
+            "version": current_tunnel_version
+        },
+        "master_connection": {
+            "url": MASTER_URL,
+            "last_successful_report": last_successful_master_contact.isoformat() if last_successful_master_contact else None,
+            "seconds_since_contact": seconds_since_contact
+        },
+        "threads": thread_health_status.copy()
+    }
+
+    http_status = 200 if status == "healthy" else 503
+    return jsonify(response), http_status
+
+def run_health_check_server():
+    """
+    Runs the Flask health check server.
+    """
+    thread_health_status["health_server"] = "running"
+    try:
+        app.run(host='0.0.0.0', port=HEALTH_CHECK_PORT, debug=False, use_reloader=False)
+    except Exception as e:
+        logging.error(f"Health check server error: {e}")
+        thread_health_status["health_server"] = "failed"
+
+def listen_for_docker_events(client, label_prefix):
+    thread_health_status[f"events_listener_{label_prefix.strip('.')}"] = "running"
+    logging.info(f"Performing initial scan of running containers for prefix {label_prefix}...")
+    try:
+        for container in client.containers.list():
+            if container.labels.get(f"{label_prefix}enable") == "true":
+                logging.info(f"Found existing container to report for {label_prefix}: {container.name}")
+                report_event_to_master("container_start", {
+                    "id": container.id,
+                    "name": container.name,
+                    "labels": container.labels
+                })
+    except Exception as e:
+        logging.error(f"Error during initial container scan for {label_prefix}: {e}")
+
+    logging.info(f"Listening for Docker events with prefix {label_prefix}...")
+    event_filters = {
+        "type": "container",
+        "label": f"{label_prefix}enable=true"
+    }
+    try:
+        for event in client.events(decode=True, filters=event_filters):
+            try:
+                if event.get("Type") == "container" and event.get("Action") in ["start", "stop", "die"]:
+                    action = event['Action']
+                    container_id = event['id']
+                    try:
+                        container = client.containers.get(container_id)
                         event_type = f"container_{action}"
-                        logging.info(f"Detected event '{action}' for container {container.name}")
+                        logging.info(f"Detected event '{action}' for container {container.name} ({label_prefix})")
                         report_event_to_master(event_type, {
                             "id": container_id,
                             "name": container.name,
-                            "labels": labels
+                            "labels": container.labels
                         })
-                except docker.errors.NotFound:
-                    logging.warning(f"Container {container_id[:12]} not found after event '{action}'. Reporting to master.")
-                    report_event_to_master({"action": action, "container_id": container_id})
-        except Exception as e:
-            logging.error(f"An error occurred in the event loop: {e}")
+                    except docker.errors.NotFound:
+                        logging.warning(f"Container {container_id[:12]} not found after event '{action}' ({label_prefix}). Reporting to master.")
+                        report_event_to_master({"action": action, "container_id": container_id})
+            except Exception as e:
+                logging.error(f"An error occurred in the event loop for {label_prefix}: {e}")
+    except Exception as e:
+        logging.error(f"Failed to connect to Docker event stream for {label_prefix}: {e}")
+        thread_health_status[f"events_listener_{label_prefix.strip('.')}"] = "failed"
+
+def start_event_listeners(client):
+    threads = []
+    label_prefixes = ["dockflare.", "cloudflare.tunnel."]
+    for prefix in label_prefixes:
+        thread = Thread(target=listen_for_docker_events, args=(client, prefix), daemon=True)
+        threads.append(thread)
+    return threads
 
 def manage_tunnels(client):
     """
     Periodically polls for commands from the master and manages a cloudflared container.
     """
     global tunnel_container, current_tunnel_token, current_tunnel_id, current_tunnel_version, current_tunnel_name, desired_tunnel_state
+    thread_health_status["tunnel_manager"] = "running"
     logging.info("Tunnel management thread started.")
 
     while True:
@@ -456,6 +546,7 @@ def manage_tunnels(client):
 
 
 def tunnel_health_monitor(client):
+    thread_health_status["health_monitor"] = "running"
     logging.info("Tunnel health monitor thread started.")
     while True:
         try:
@@ -470,6 +561,7 @@ def periodic_status_reporter(client):
     """
     Periodic reporter: sends heartbeat and full status_report of enabled containers.
     """
+    thread_health_status["status_reporter"] = "running"
     logging.info("Status reporter thread started.")
     while True:
         if not AGENT_ID:
@@ -518,6 +610,11 @@ def cleanup():
 if __name__ == "__main__":
     load_agent_id()
     load_tunnel_state()
+
+    logging.info(f"Starting health check server on port {HEALTH_CHECK_PORT}")
+    health_thread = Thread(target=run_health_check_server, daemon=True)
+    health_thread.start()
+
     if register_with_master():
         docker_client = docker.from_env()
         try:
@@ -526,8 +623,9 @@ if __name__ == "__main__":
             tunnel_thread.start()
             status_thread = Thread(target=periodic_status_reporter, args=(docker_client,), daemon=True)
             status_thread.start()
-            events_thread = Thread(target=listen_for_docker_events, args=(docker_client,), daemon=True)
-            events_thread.start()
+            event_threads = start_event_listeners(docker_client)
+            for t in event_threads:
+                t.start()
             monitor_thread = Thread(target=tunnel_health_monitor, args=(docker_client,), daemon=True)
             monitor_thread.start()
             while True:

--- a/DockFlare-Agent/main.py
+++ b/DockFlare-Agent/main.py
@@ -9,6 +9,7 @@ import tempfile
 from threading import Thread
 from dotenv import load_dotenv
 import cloudflare_api
+import transport
 
 DEFAULT_CLOUDFLARED_IMAGE = "cloudflare/cloudflared:2025.9.0"
 _SHA256_HEX_RE = re.compile(r"^[A-Fa-f0-9]{64}$")
@@ -253,7 +254,7 @@ def register_with_master():
     while True:
         logging.info(f"Attempting to register with master at {endpoint}")
         try:
-            headers = {"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"}
+            headers = transport.get_master_headers()
             custom_display_name = os.getenv("AGENT_DISPLAY_NAME", "").strip()
             default_display_name = f"agent-{AGENT_ID[:8]}" if AGENT_ID else "dockflare-agent"
             payload = {
@@ -300,7 +301,7 @@ def report_event_to_master(event_type, container_data=None):
         if container_data:
             payload["container"] = container_data
 
-        headers = {"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"}
+        headers = transport.get_master_headers()
         endpoint = f"{MASTER_URL}/api/v2/agents/{AGENT_ID}/events"
 
         # Log endpoint and payload at debug level so container logs show activity without being too noisy at info.
@@ -365,7 +366,7 @@ def manage_tunnels(client):
             time.sleep(10)
             continue
         try:
-            headers = {"Authorization": f"Bearer {API_KEY}"}
+            headers = transport.get_master_headers(include_json=False)
             endpoint = f"{MASTER_URL}/api/v2/agents/{AGENT_ID}/commands"
             response = requests.get(endpoint, headers=headers, timeout=15)
             response.raise_for_status()
@@ -440,7 +441,9 @@ def manage_tunnels(client):
                         continue
                     rules = cmd.get("rules", {})
                     ingress_rules = cloudflare_api.generate_ingress_rules(rules)
-                    success = cloudflare_api.update_tunnel_config(MASTER_URL, API_KEY, current_tunnel_id, ingress_rules)
+                    success = cloudflare_api.update_tunnel_config(
+                        MASTER_URL, transport.get_master_headers(), current_tunnel_id, ingress_rules
+                    )
                     if success:
                         logging.info("Tunnel configuration updated successfully")
                     else:

--- a/DockFlare-Agent/transport.py
+++ b/DockFlare-Agent/transport.py
@@ -1,0 +1,49 @@
+"""
+Transport layer for Agent-to-Master HTTP requests.
+
+Centralizes authentication headers: Bearer API key for master-agent auth,
+and optional Cloudflare Access Service Token headers when the Master is
+protected by Access policies.
+"""
+
+import os
+import logging
+
+# Logged once when Service Token is first used.
+_service_token_logged = False
+
+
+def get_master_headers(include_json: bool = True) -> dict:
+    """
+    Returns headers for HTTP requests to the DockFlare Master.
+
+    Always includes Authorization Bearer (DOCKFLARE_API_KEY).
+    If CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET are set, adds
+    CF-Access-Client-Id and CF-Access-Client-Secret for Cloudflare Access.
+
+    Args:
+        include_json: If True, adds Content-Type: application/json.
+
+    Returns:
+        Dict of headers suitable for requests.get/post.
+    """
+    global _service_token_logged
+    api_key = os.getenv("DOCKFLARE_API_KEY", "")
+    headers = {"Authorization": f"Bearer {api_key}"}
+    if include_json:
+        headers["Content-Type"] = "application/json"
+
+    # Cloudflare Access Service Token (optional). Read at call time so
+    # load_dotenv() has run. See: https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/service-tokens/
+    cf_client_id = os.getenv("CF_ACCESS_CLIENT_ID", "").strip()
+    cf_client_secret = os.getenv("CF_ACCESS_CLIENT_SECRET", "").strip()
+    if cf_client_id and cf_client_secret:
+        headers["CF-Access-Client-Id"] = cf_client_id
+        headers["CF-Access-Client-Secret"] = cf_client_secret
+        if not _service_token_logged:
+            logging.getLogger(__name__).info(
+                "Cloudflare Access Service Token auth enabled for Master requests"
+            )
+            _service_token_logged = True
+
+    return headers

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-info}
     volumes:
       - agent_data:/app/data
+    ports:
+      - "127.0.0.1:${HEALTH_CHECK_PORT:-8080}:${HEALTH_CHECK_PORT:-8080}"
     depends_on:
       - docker-socket-proxy
     networks:
@@ -160,12 +162,17 @@ Once both files are in place, run `docker-compose up -d` to start the agent.
 
 1. **Bootstrapping** – environment variables are loaded, logging is configured, and cached agent identity/tunnel data are restored from `/app/data`.
 2. **Registration** – the agent authenticates with the master using `DOCKFLARE_API_KEY`, receives (or refreshes) its Agent ID, and persists it locally.
-3. **Thread fan-out** – shared Docker client powers four background workers:
+3. **HTTP health server** – Flask server exposes `/health` on `HEALTH_CHECK_PORT` (default 8080) with status, tunnel state, and thread health.
+4. **Thread fan-out** – shared Docker client powers background workers:
    - `manage_tunnels` polls for commands (`start_tunnel`, `stop_tunnel`, `update_tunnel_config`).
    - `periodic_status_reporter` emits heartbeats and summaries of labelled containers every `REPORT_INTERVAL_SECONDS`.
-   - `listen_for_docker_events` streams container lifecycle events for `dockflare.enable=true` workloads.
+   - `listen_for_docker_events` streams container lifecycle events for `dockflare.enable` and `cloudflare.tunnel.enable` labels.
    - `tunnel_health_monitor` verifies the managed `cloudflared` container remains healthy.
-4. **Shutdown** – `cleanup()` stops and removes the managed tunnel container before the agent exits.
+5. **Shutdown** – `cleanup()` stops and removes the managed tunnel container before the agent exits.
+
+#### Health Check Endpoint
+
+`GET /health` returns JSON with `status` (healthy/degraded/unhealthy), `agent_id`, `tunnel` state, `master_connection` (last successful report, seconds since contact), and `threads` status. Healthy when last master contact < 120s; degraded when < 300s.
 
 ### Cloudflare Helper Module
 
@@ -201,6 +208,7 @@ The agent is configured using environment variables, typically through the `.env
 | `LOG_LEVEL` | ❌ | Python logging level (`INFO` by default). |
 | `REPORT_INTERVAL_SECONDS` | ❌ | Cadence for status reports (defaults to `30`). |
 | `TZ` | ❌ | Host timezone exposed to the container (`UTC` by default). |
+| `HEALTH_CHECK_PORT` | ❌ | HTTP health check server port (defaults to `8080`). |
 | `CF_ACCESS_CLIENT_ID` | ❌ | Cloudflare Access Service Token Client ID (when Master is behind Access). |
 | `CF_ACCESS_CLIENT_SECRET` | ❌ | Cloudflare Access Service Token Client Secret (when Master is behind Access). |
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ Once both files are in place, run `docker-compose up -d` to start the agent.
 ├── DockFlare-Agent/
 │   ├── __init__.py
 │   ├── cloudflare_api.py
-│   └── main.py
+│   ├── main.py
+│   └── transport.py
 ├── Dockerfile
 ├── docker-compose.yml
 ├── env-example
@@ -170,9 +171,9 @@ Once both files are in place, run `docker-compose up -d` to start the agent.
 
 `DockFlare-Agent/cloudflare_api.py` provides the thin wrapper that the agent uses to proxy Cloudflare API calls through the master:
 
-- `get_account_id(master_url, api_key)` – resolves the Cloudflare account the master exposes to agents.
+- `get_account_id(master_url, headers)` – resolves the Cloudflare account the master exposes to agents.
 - `generate_ingress_rules(rules)` – converts desired ingress records into a tunnel configuration payload.
-- `update_tunnel_config(master_url, api_key, tunnel_id, ingress_rules)` – pushes ingress updates via the master’s API.
+- `update_tunnel_config(master_url, headers, tunnel_id, ingress_rules)` – pushes ingress updates via the master’s API.
 
 ---
 
@@ -200,6 +201,12 @@ The agent is configured using environment variables, typically through the `.env
 | `LOG_LEVEL` | ❌ | Python logging level (`INFO` by default). |
 | `REPORT_INTERVAL_SECONDS` | ❌ | Cadence for status reports (defaults to `30`). |
 | `TZ` | ❌ | Host timezone exposed to the container (`UTC` by default). |
+| `CF_ACCESS_CLIENT_ID` | ❌ | Cloudflare Access Service Token Client ID (when Master is behind Access). |
+| `CF_ACCESS_CLIENT_SECRET` | ❌ | Cloudflare Access Service Token Client Secret (when Master is behind Access). |
+
+#### Cloudflare Access (Optional)
+
+When the DockFlare Master is protected by Cloudflare Access policies, set `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` to a [Cloudflare Service Token](https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/service-tokens/). Create the token in Cloudflare One > Access > Service credentials > Service Tokens, add it to your Access application policy with **Service Auth** action, and pass both values to the agent. This avoids IP bypass policies and enables deployment on any host.
 
 The agent persists lightweight state inside `/app/data`:
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Deploy agents on any Docker-capable host to extend DockFlare beyond a single ser
 - **Real-time visibility** – agents stream lifecycle events, periodic status reports, and tunnel metrics back to the master.
 - **Least privilege** – per-agent API keys can be rotated or revoked without affecting the rest of the fleet.
 - **Resilient execution** – cached tunnel state lets agents ride out transient master outages.
+- **Cloudflare Access** – when the Master is behind Application Access, use a Service Token instead of IP bypass; deploy agents on any host.
 
 <details>
   <summary><strong>🚀 Quick Start: Deploying the Agent</strong></summary>
@@ -83,6 +84,8 @@ services:
       - DOCKER_HOST=${DOCKER_HOST:-tcp://docker-socket-proxy:2375}
       - TZ=${TZ:-UTC}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+      - CF_ACCESS_CLIENT_ID=${CF_ACCESS_CLIENT_ID}
+      - CF_ACCESS_CLIENT_SECRET=${CF_ACCESS_CLIENT_SECRET}
     volumes:
       - agent_data:/app/data
     ports:
@@ -113,10 +116,14 @@ DOCKFLARE_MASTER_URL=https://dockflare.example.com
 DOCKFLARE_API_KEY=agent_api_key_goes_here
 DOCKER_HOST=tcp://docker-socket-proxy:2375
 AGENT_DISPLAY_NAME=Production Server
-# control the docker image used for the managed cloudflared tunnel (accepts repo:tag or repo@sha256:<digest>)
 CLOUDFLARED_IMAGE=cloudflare/cloudflared:2025.9.0
 LOG_LEVEL=info
 TZ=Europe/Zurich
+HEALTH_CHECK_PORT=8080
+
+# Optional: when Master is behind Cloudflare Application Access (see Cloudflare Access section)
+# CF_ACCESS_CLIENT_ID=
+# CF_ACCESS_CLIENT_SECRET=
 ```
 
 Once both files are in place, run `docker-compose up -d` to start the agent.
@@ -209,12 +216,30 @@ The agent is configured using environment variables, typically through the `.env
 | `REPORT_INTERVAL_SECONDS` | ❌ | Cadence for status reports (defaults to `30`). |
 | `TZ` | ❌ | Host timezone exposed to the container (`UTC` by default). |
 | `HEALTH_CHECK_PORT` | ❌ | HTTP health check server port (defaults to `8080`). |
-| `CF_ACCESS_CLIENT_ID` | ❌ | Cloudflare Access Service Token Client ID (when Master is behind Access). |
-| `CF_ACCESS_CLIENT_SECRET` | ❌ | Cloudflare Access Service Token Client Secret (when Master is behind Access). |
+| `CF_ACCESS_CLIENT_ID` | ❌ | Cloudflare Access Service Token Client ID (when Master is behind Application Access). |
+| `CF_ACCESS_CLIENT_SECRET` | ❌ | Cloudflare Access Service Token Client Secret (when Master is behind Application Access). |
 
-#### Cloudflare Access (Optional)
+#### Cloudflare Access Service Token (Optional)
 
-When the DockFlare Master is protected by Cloudflare Access policies, set `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` to a [Cloudflare Service Token](https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/service-tokens/). Create the token in Cloudflare One > Access > Service credentials > Service Tokens, add it to your Access application policy with **Service Auth** action, and pass both values to the agent. This avoids IP bypass policies and enables deployment on any host.
+Use a Cloudflare Access Service Token **only when** the DockFlare Master is protected by Cloudflare Application Access. The agent must send `CF-Access-Client-Id` and `CF-Access-Client-Secret` headers so Cloudflare allows requests through before they reach the Master.
+
+**Requirements:**
+- The Master domain is behind a Cloudflare Access Application.
+- A Service Token is created and added to an Access Policy.
+- That Policy is applied to the Access Application protecting the Master.
+
+**Create a Service Token:**
+
+1. In [Cloudflare One](https://one.dash.cloudflare.com), go to **Access** > **Service credentials** > **Service Tokens**.
+2. Select **Create Service Token**.
+3. Name the token (e.g. `DockFlare Agent`).
+4. Choose a **Service Token Duration** (e.g. 1 year).
+5. Select **Generate token**.
+6. Copy the **Client ID** and **Client Secret** immediately (the secret is shown only once).
+7. Add the token to your Access Application: edit the Application protecting the Master, add a Policy with **Service Auth** action, and include this Service Token.
+8. Set `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET` in the agent `.env` and ensure they are passed to the container (e.g. via `env_file` and `environment` in docker-compose).
+
+See [Cloudflare Service Tokens](https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/service-tokens/) for full documentation. This avoids IP bypass policies and enables deployment on any host.
 
 The agent persists lightweight state inside `/app/data`:
 
@@ -247,6 +272,7 @@ Recommended practices:
 | Symptom | Resolution |
 |---------|------------|
 | Agent stuck in `pending` | Verify the API key, ensure the agent can reach the master, and enrol it from the UI. |
+| 401/403 when Master is behind Access | Set `CF_ACCESS_CLIENT_ID` and `CF_ACCESS_CLIENT_SECRET`; ensure the Service Token is in a Policy with **Service Auth** applied to the Master's Access Application. |
 | Commands never clear | Confirm Redis connectivity and that host clocks are in sync. |
 | DNS or Access policies not updating | Check agent logs (`docker logs dockflare-agent`) and confirm cloudflared is running. |
 | Heartbeat offline | Inspect network path and TLS configuration between agent and master. |

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ networks:
 
 Next, create a `.env` file in the same directory. This file provides the configuration values for the agent service defined above. Refer to the **Configuration** section below for more details on each variable.
 
-```
+```ini
 DOCKFLARE_MASTER_URL=https://dockflare.example.com
 DOCKFLARE_API_KEY=agent_api_key_goes_here
 DOCKER_HOST=tcp://docker-socket-proxy:2375
@@ -276,6 +276,8 @@ Recommended practices:
 | Commands never clear | Confirm Redis connectivity and that host clocks are in sync. |
 | DNS or Access policies not updating | Check agent logs (`docker logs dockflare-agent`) and confirm cloudflared is running. |
 | Heartbeat offline | Inspect network path and TLS configuration between agent and master. |
+
+For deployment gotchas (permissions, cloudflare-net, DNS zone scoping), see [Deployment Troubleshooting](docs/DEPLOYMENT-TROUBLESHOOTING.md).
 
 The `overview.json` sample captures the telemetry an active agent reports back to the master and can be used as a reference when debugging payloads.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+#version: '3.8'
 
 services:
   docker-socket-proxy:
@@ -17,32 +17,68 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
-      - dockflare-internal
-      
+      # - dockflare-internal
+      - docker-socket-proxy-net
+
+  cloudflared-net-init:
+    image: docker:cli
+    environment:
+      - DOCKER_HOST=${DOCKER_HOST:-tcp://docker-socket-proxy:2375}
+    command:
+      - sh
+      - -c
+      - |
+        echo "Checking if Network cloudflare-net exists..."
+        if [ -z "$(docker network ls -f name=cloudflare-net -q)" ]; then
+          echo "Network cloudflare-net does not exist, creating..."
+          docker network create cloudflare-net
+          echo "Network cloudflare-net created."
+        else
+          echo "Network cloudflare-net exists, skipping creation."
+        fi
+        echo "Network cloudflare-net check complete"
+    restart: "no"
+    depends_on:
+      docker-socket-proxy:
+        condition: service_started
+    networks:
+      - docker-socket-proxy-net
+
   dockflare-agent:
-    image: alplat/dockflare-agent:latest
+    # image: alplat/dockflare-agent:latest
+    image: dockflare-agent:local
     container_name: dockflare-agent
     restart: unless-stopped
     env_file:
       - .env
     environment:
       - DOCKER_HOST=${DOCKER_HOST:-tcp://docker-socket-proxy:2375}
+      - DOCKFLARE_API_KEY=${DOCKFLARE_API_KEY}
       - TZ=${TZ:-UTC}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - CF_ACCESS_CLIENT_ID=${CF_ACCESS_CLIENT_ID}
       - CF_ACCESS_CLIENT_SECRET=${CF_ACCESS_CLIENT_SECRET}
     volumes:
-      # docker volume
-      # - agent_data:/app/data
-      # docker bind mount
       - ${DOCKFLARE_DATA_PATH}:/app/data
     depends_on:
-      - docker-socket-proxy
+      docker-socket-proxy:
+        condition: service_started
+      cloudflared-net-init:
+        condition: service_completed_successfully
     networks:
       - cloudflare-net
       - dockflare-internal
+      - docker-socket-proxy-net
 
-# Only if using docker volume
+  dockflare-agent-init:
+    image: alpine:3.20
+    command: ["sh", "-c", "echo 'checking permissions...' && chown -R ${DOCKFLARE_UID:-65532}:${DOCKFLARE_GID:-65532} /app/data"]
+    volumes:
+      - ${DOCKFLARE_DATA_PATH}:/app/data
+    networks:
+      - dockflare-internal
+    restart: "no"
+
 # volumes:
 #   agent_data:
 
@@ -52,3 +88,5 @@ networks:
     external: true
   dockflare-internal:
     name: dockflare-internal
+  docker-socket-proxy-net:
+    name: docker-socket-proxy-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,6 @@ services:
 networks:
   cloudflare-net:
     name: cloudflare-net
-    external: true
   dockflare-internal:
     name: dockflare-internal
   docker-socket-proxy-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,16 +29,22 @@ services:
       - DOCKER_HOST=${DOCKER_HOST:-tcp://docker-socket-proxy:2375}
       - TZ=${TZ:-UTC}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+      - CF_ACCESS_CLIENT_ID=${CF_ACCESS_CLIENT_ID}
+      - CF_ACCESS_CLIENT_SECRET=${CF_ACCESS_CLIENT_SECRET}
     volumes:
-      - agent_data:/app/data
+      # docker volume
+      # - agent_data:/app/data
+      # docker bind mount
+      - ${DOCKFLARE_DATA_PATH}:/app/data
     depends_on:
       - docker-socket-proxy
     networks:
       - cloudflare-net
       - dockflare-internal
 
-volumes:
-  agent_data:
+# Only if using docker volume
+# volumes:
+#   agent_data:
 
 networks:
   cloudflare-net:

--- a/docs/DEPLOYMENT-TROUBLESHOOTING.md
+++ b/docs/DEPLOYMENT-TROUBLESHOOTING.md
@@ -1,0 +1,145 @@
+# Deployment Troubleshooting
+
+Short notes to bypass common issues when deploying the DockFlare Agent. See [README](../README.md) for full setup.
+
+---
+
+## cloudflare-net
+
+The `cloudflared-net-init` service ensures `cloudflare-net` exists before the agent starts. Agent or Master can deploy first; the init creates the network when missing via `docker-socket-proxy`.
+
+```yaml
+cloudflared-net-init:
+  image: docker:cli
+  environment:
+    - DOCKER_HOST=${DOCKER_HOST:-tcp://docker-socket-proxy:2375}
+  command:
+    - sh
+    - -c
+    - |
+      if [ -z "$(docker network ls -f name=cloudflare-net -q)" ]; then
+        echo "Network cloudflare-net does not exist, creating..."
+        docker network create cloudflare-net
+      else
+        echo "Network cloudflare-net exists, skipping creation."
+      fi
+  restart: "no"
+  depends_on:
+    docker-socket-proxy:
+      condition: service_started
+  networks:
+    - docker-socket-proxy-net
+```
+
+Add to `dockflare-agent`:
+
+```yaml
+depends_on:
+  docker-socket-proxy:
+    condition: service_started
+  cloudflared-net-init:
+    condition: service_completed_successfully
+networks:
+  - cloudflare-net
+  # ... other networks
+```
+
+Declare the network in the stack
+
+```yaml
+networks:
+  cloudflare-net:
+    name: cloudflare-net
+```
+
+Declare the network in conatiners managed by dockflare-agent:
+
+```yaml
+networks:
+  cloudflare-net:
+    name: cloudflare-net
+    external: true
+```
+
+---
+
+## Permissions (bind mounts)
+
+With bind mounts, the agent may fail to persist state (re-enrolment at each restart). Add an init that fixes ownership before the agent starts:
+
+```yaml
+dockflare-agent-init:
+  image: alpine:3.20
+  command: ["sh", "-c", "echo 'checking permissions...' && chown -R ${DOCKFLARE_UID:-65532}:${DOCKFLARE_GID:-65532} /app/data"]
+  volumes:
+    - ${DOCKFLARE_DATA_PATH}:/app/data
+  networks:
+    - dockflare-internal
+  restart: "no"
+```
+
+Set `DOCKFLARE_UID` and `DOCKFLARE_GID` in `.env` (default 65532). Add to `dockflare-agent`:
+
+```yaml
+depends_on:
+  dockflare-agent-init:
+    condition: service_completed_successfully
+```
+
+---
+
+## Master behind Cloudflare Access
+
+Use a Service Token or IP allow policy so the agent can reach the Master. See [Cloudflare Access Service Token](../README.md#cloudflare-access-service-token) in the README.
+
+---
+
+## DNS in wrong zone
+
+If records are wrongly created in another zone (e.g. main domain instead of lab domain), scope the zone:
+
+On the **managed container**:
+
+```yaml
+labels:
+  - "dockflare.zonename=<lab_domain>.tld"
+```
+
+Or via **environment** on the agent / Master:
+
+```yaml
+environment:
+  - TUNNEL_DNS_SCAN_ZONE_NAMES="<lab_domain>.tld"
+```
+
+---
+
+## docker-socket-proxy-net
+
+Use a dedicated network for the socket proxy so it can be shared across stacks (Master, Agent, others). Move the proxy off `dockflare-internal`:
+
+```yaml
+docker-socket-proxy:
+  # ...
+  networks:
+    - docker-socket-proxy-net
+```
+
+Attach `docker-socket-proxy-net` to services that need Docker API access (`cloudflared-net-init`, `dockflare-agent`):
+
+```yaml
+dockflare-agent:
+  # ...
+  networks:
+    - cloudflare-net
+    - dockflare-internal
+    - docker-socket-proxy-net
+```
+
+Declare:
+
+```yaml
+networks:
+  docker-socket-proxy-net:
+    name: docker-socket-proxy-net
+```

--- a/env-example
+++ b/env-example
@@ -1,16 +1,29 @@
-DOCKFLARE_MASTER_URL=https://dockflare.example.com
-DOCKFLARE_API_KEY=agent_api_key_goes_here
+####################################
+# 🛠️ DOCKER HOME PATH 🛠️ #
+####################################
+
+DOCKER_HOME=/srv/docker
+DOCKFLARE_DATA_PATH=${DOCKER_HOME}/volumes/dockflare-agentdata/
+DOCKFLARE_UID=65532
+DOCKFLARE_GID=65532
+
+####################################
+# 🛠️ CLOUDFLARE VARIABLES 🛠️ #
+####################################
+
+# Cloudflare Access Service Token (required when Master is behind Access)
+CF_ACCESS_CLIENT_ID=<your-access-client-id>.access
+CF_ACCESS_CLIENT_SECRET=<your-access-client-secret>
+
+####################################
+# 🛠️ DOCKFLARE VARIABLES 🛠️ #
+####################################
+
+DOCKFLARE_MASTER_URL=https://dockflare.mydomain.com
+DOCKFLARE_API_KEY=<dockflare-api-key>
 DOCKER_HOST=tcp://docker-socket-proxy:2375
-AGENT_DISPLAY_NAME=Production Server
+AGENT_DISPLAY_NAME=<agent-display-name>
 # control the docker image used for the managed cloudflared tunnel (accepts repo:tag or repo@sha256:<digest>)
 CLOUDFLARED_IMAGE=cloudflare/cloudflared:2025.9.0
 LOG_LEVEL=info
-TZ=Europe/Zurich
-# HTTP health check server port (default 8080)
-HEALTH_CHECK_PORT=8080
-
-# Optional: Cloudflare Access Service Token (when Master is behind Access)
-# Create a service token in Cloudflare One > Access > Service credentials > Service Tokens.
-# Add the token to your Access application policy with Service Auth action.
-# CF_ACCESS_CLIENT_ID=
-# CF_ACCESS_CLIENT_SECRET=
+TZ=Europe/Paris

--- a/env-example
+++ b/env-example
@@ -6,3 +6,9 @@ AGENT_DISPLAY_NAME=Production Server
 CLOUDFLARED_IMAGE=cloudflare/cloudflared:2025.9.0
 LOG_LEVEL=info
 TZ=Europe/Zurich
+
+# Optional: Cloudflare Access Service Token (when Master is behind Access)
+# Create a service token in Cloudflare One > Access > Service credentials > Service Tokens.
+# Add the token to your Access application policy with Service Auth action.
+# CF_ACCESS_CLIENT_ID=
+# CF_ACCESS_CLIENT_SECRET=

--- a/env-example
+++ b/env-example
@@ -6,6 +6,8 @@ AGENT_DISPLAY_NAME=Production Server
 CLOUDFLARED_IMAGE=cloudflare/cloudflared:2025.9.0
 LOG_LEVEL=info
 TZ=Europe/Zurich
+# HTTP health check server port (default 8080)
+HEALTH_CHECK_PORT=8080
 
 # Optional: Cloudflare Access Service Token (when Master is behind Access)
 # Create a service token in Cloudflare One > Access > Service credentials > Service Tokens.

--- a/env-example
+++ b/env-example
@@ -19,11 +19,13 @@ CF_ACCESS_CLIENT_SECRET=<your-access-client-secret>
 # 🛠️ DOCKFLARE VARIABLES 🛠️ #
 ####################################
 
-DOCKFLARE_MASTER_URL=https://dockflare.mydomain.com
-DOCKFLARE_API_KEY=<dockflare-api-key>
+DOCKFLARE_MASTER_URL=https://dockflare.example.com
+DOCKFLARE_API_KEY=agent_api_key_goes_here
 DOCKER_HOST=tcp://docker-socket-proxy:2375
-AGENT_DISPLAY_NAME=<agent-display-name>
+AGENT_DISPLAY_NAME=Production Server
 # control the docker image used for the managed cloudflared tunnel (accepts repo:tag or repo@sha256:<digest>)
 CLOUDFLARED_IMAGE=cloudflare/cloudflared:2025.9.0
 LOG_LEVEL=info
-TZ=Europe/Paris
+TZ=Europe/Zurich
+# HTTP health check server port (default 8080)
+HEALTH_CHECK_PORT=8080

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.31.0
 docker==6.1.3
 python-dotenv==1.0.0
+flask>=3.0.0


### PR DESCRIPTION
Adds an enhanced docker-compose.yml ( to apply permission on bind volumes, precreate the cloudflare-net ) and
a deployment troubleshooting document to help users bypass common issues encountered when deploying the Agent.

- **cloudflare-net**: `cloudflared-net-init` ensures the network exists; Agent or Master can deploy first
- **Permissions (bind mounts)**: init service to fix ownership and prevent Agent Amnesia / re-enrolment at restart
- **Master behind Access**: Service Token or IP allow for agent call-home (links to README)
- **DNS in wrong zone**: `dockflare.zonename` label + `TUNNEL_DNS_SCAN_ZONE_NAMES` to scope records
- **docker-socket-proxy-net**: shared network pattern for the socket proxy across stacks